### PR TITLE
Remove Android focus log

### DIFF
--- a/paper-inky-focus-behavior.html
+++ b/paper-inky-focus-behavior.html
@@ -25,7 +25,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _focusedChanged: function(receivedFocusFromKeyboard) {
       if (navigator.userAgent.match(/Android/)) {
-        return console.debug('[PaperInkyFocusBehavior] Ignoring focus on Android');
+        return;
       }
       if (receivedFocusFromKeyboard) {
         this.ensureRipple();


### PR DESCRIPTION
At least until we figure out a good way of suppressing `console.debug` logs in Sentry.